### PR TITLE
fix: `tree-sitter.json` now obeys upstream schema

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
   "grammars": [
     {
       "name": "janet_simple",
@@ -14,6 +15,9 @@
   ],
   "metadata": {
     "version": "0.0.8",
-    "description": "A Janet grammar for tree-sitter"
+    "description": "A Janet grammar for tree-sitter",
+    "links": {
+      "repository": "https://github.com/sogaiu/tree-sitter-janet-simple"
+    }
   }
 }


### PR DESCRIPTION
`name` is not allowed to contain `-`'s, see
<https://github.com/tree-sitter/tree-sitter/blob/v0.26.5/docs/src/assets/schemas/config.schema.json#L13-L17>.

Alternatively, would it be better to relax the regex upstream? This is not the only repo with this issue, see
<https://github.com/tree-sitter/tree-sitter-ql-dbscheme/pull/7>.